### PR TITLE
Tidied up template for index.html

### DIFF
--- a/build/templates/index.html.js
+++ b/build/templates/index.html.js
@@ -3,6 +3,8 @@ var tpl = "<!doctype html>\n" +
           "<head>\n" +
           "  <title><%= name %></title>\n" +
           "  <link rel=\"stylesheet\" type=\"text/css\" href=\"app/public/stylesheets/app.min.css\">\n" +
+          "<script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular.min.js\"></script>" +
+          "<script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular-aria.min.js\"></script>" +
           "  <script type=\"text/javascript\" src=\"./app/public/components/jquery/dist/jquery.min.js\"></script>\n" +
           "  <script type=\"text/javascript\" src=\"./app/public/javascripts/index.js\"></script>\n" +
           "</head>\n" +

--- a/build/templates/index.html.js
+++ b/build/templates/index.html.js
@@ -1,15 +1,15 @@
 var tpl = "<!doctype html>\n" +
-          "<html ng-app='<%= appName %>'>\n" +
+          "<html ng-app=\"<%= appName %>\">\n" +
           "<head>\n" +
           "  <title><%= name %></title>\n" +
-          "  <link rel='stylesheet' type='text/css' href='app/public/stylesheets/app.min.css'>\n" +
-          "  <script type='text/javascript' src='./app/public/components/jquery/dist/jquery.min.js'></script>\n" +
-          "  <script type='text/javascript' src='./app/public/javascripts/index.js'></script>\n" +
+          "  <link rel=\"stylesheet\" type=\"text/css\" href=\"app/public/stylesheets/app.min.css\">\n" +
+          "  <script type=\"text/javascript\" src=\"./app/public/components/jquery/dist/jquery.min.js\"></script>\n" +
+          "  <script type=\"text/javascript\" src=\"./app/public/javascripts/index.js\"></script>\n" +
           "</head>\n" +
           "<body>\n" +
-          "  <header ng-include=\"'<%= root %>/views/shared/header.html'\"></header>\n" +
-          "  <main class='container' ui-view></main>\n" +
-          "  <footer class='container' ng-include=\"'<%= root %>/views/shared/footer.html'\"></footer>\n"  +
+          "  <header ng-include=\".<%= root %>/views/shared/header.html\"></header>\n" +
+          "  <main class=\"container\" ui-view></main>\n" +
+          "  <footer class=\"container\" ng-include=\".<%= root %>/views/shared/footer.html\"></footer>\n"  +
           "</body>\n"  +
           "</html>\n";
 

--- a/build/templates/index.html.js
+++ b/build/templates/index.html.js
@@ -3,15 +3,15 @@ var tpl = "<!doctype html>\n" +
           "<head>\n" +
           "  <title><%= name %></title>\n" +
           "  <link rel=\"stylesheet\" type=\"text/css\" href=\"app/public/stylesheets/app.min.css\">\n" +
-          "<script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular.min.js\"></script>" +
-          "<script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular-aria.min.js\"></script>" +
+          "  <script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular.min.js\"></script>\n" +
+          "  <script type=\"text/javascript\" src=\"./app/public/components/angularjs/angularjs.1.4.2.angular-aria.min.js\"></script>\n" +
           "  <script type=\"text/javascript\" src=\"./app/public/components/jquery/dist/jquery.min.js\"></script>\n" +
           "  <script type=\"text/javascript\" src=\"./app/public/javascripts/index.js\"></script>\n" +
           "</head>\n" +
           "<body>\n" +
-          "  <header ng-include=\".<%= root %>/views/shared/header.html\"></header>\n" +
+          "  <header ng-include=\"./<%= root %>/views/shared/header.html\"></header>\n" +
           "  <main class=\"container\" ui-view></main>\n" +
-          "  <footer class=\"container\" ng-include=\".<%= root %>/views/shared/footer.html\"></footer>\n"  +
+          "  <footer class=\"container\" ng-include=\"./<%= root %>/views/shared/footer.html\"></footer>\n"  +
           "</body>\n"  +
           "</html>\n";
 


### PR DESCRIPTION
The current `/build/templates/index.html.js` code generates the following

``` html
  <header ng-include="'app/public/appName/views/shared/header.html'"></header>
  <main class='container' ui-view></main>
  <footer class='container' ng-include="'app/public/appName/views/shared/footer.html'"></footer>
```

which has single & double quotes. My changes to the file should fix this and use double-quotes throughout.

I also added links to directories for `angular.min.js` & `angular-aria.min.js`, since it seemed useful, given you use `ng-app` in the file already. 
